### PR TITLE
`api.helpers` patch

### DIFF
--- a/fastadmin/api/helpers.py
+++ b/fastadmin/api/helpers.py
@@ -30,9 +30,8 @@ def sanitize_filter_key(key: str, fields: list[ModelFieldWidgetSchema]) -> tuple
     :return: A tuple of sanitized key and condition.
     """
     if "__" not in key:
-        key = f"{key}__exact"
-    field_name = key.split("__", 1)[0]
-    condition = key.split("__", 1)[1]
+        key += "__exact"
+    field_name, _, condition = key.partition("__")
     field: ModelFieldWidgetSchema | None = next((field for field in fields if field.name == field_name), None)
     if field and field.filter_widget_props.get("parentModel") and not field.is_m2m:
         field_name = f"{field_name}_id"

--- a/fastadmin/api/helpers.py
+++ b/fastadmin/api/helpers.py
@@ -61,9 +61,9 @@ def is_valid_id(id: UUID | int) -> bool:
 
 
 def is_valid_base64(value: str) -> bool:
-    """Check if s is a valid base64.
+    """Check if a string is a valid base64.
 
-    :param s: A string to test.
+    :param value: A string to test.
     :return: True if s is a valid base64, False otherwise.
     """
     try:

--- a/fastadmin/api/helpers.py
+++ b/fastadmin/api/helpers.py
@@ -52,26 +52,13 @@ def is_valid_uuid(uuid_to_test: str) -> bool:
     return str(uuid_obj) == uuid_to_test
 
 
-def is_digit(digit_to_test: str) -> bool:
-    """Check if digit_to_test is a digit.
-
-    :param digit_to_test: A digit to test.
-    :return: True if digit_to_test is a digit, False otherwise.
-    """
-    try:
-        int(digit_to_test)
-    except ValueError:
-        return False
-    return True
-
-
 def is_valid_id(id: UUID | int) -> bool:
     """Check if id is a valid id.
 
     :param id: An id to test.
     :return: True if id is a valid id, False otherwise.
     """
-    return is_digit(str(id)) or is_valid_uuid(str(id))
+    return str(id).isdigit() or is_valid_uuid(str(id))
 
 
 def is_valid_base64(value: str) -> bool:

--- a/fastadmin/api/helpers.py
+++ b/fastadmin/api/helpers.py
@@ -34,7 +34,7 @@ def sanitize_filter_key(key: str, fields: list[ModelFieldWidgetSchema]) -> tuple
     field_name, _, condition = key.partition("__")
     field: ModelFieldWidgetSchema | None = next((field for field in fields if field.name == field_name), None)
     if field and field.filter_widget_props.get("parentModel") and not field.is_m2m:
-        field_name = f"{field_name}_id"
+        field_name += "_id"
     return field_name, condition
 
 

--- a/tests/api/test_helpers.py
+++ b/tests/api/test_helpers.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import jwt
 
-from fastadmin.api.helpers import is_digit, is_valid_id, is_valid_uuid, sanitize_filter_value
+from fastadmin.api.helpers import is_valid_id, is_valid_uuid, sanitize_filter_value
 from fastadmin.api.service import get_user_id_from_session_id
 from fastadmin.settings import settings
 
@@ -21,13 +21,6 @@ async def test_is_valid_uuid():
     assert is_valid_uuid(str(uuid.uuid4())) is True
     assert is_valid_uuid(str(uuid.uuid5(uuid.uuid4(), "test"))) is True
     assert is_valid_uuid("invalid") is False
-
-
-async def test_is_digit():
-    assert is_digit("true") is False
-    assert is_digit("0.2") is False
-    assert is_digit("-1") is True
-    assert is_digit("foo") is False
 
 
 async def test_is_valid_id():


### PR DESCRIPTION
This PR replaces unnecessary `is_digit()` with the built-in `str.isdigit` method, replaces f-strings with inplace concatenation in `sanitize_filter_key()` and fixes the `is_valid_base64()` docstring.