### PR TITLE
Adding custom label for field and help text for field

### DIFF
--- a/examples/fastapi_sqlalchemy/example.py
+++ b/examples/fastapi_sqlalchemy/example.py
@@ -20,7 +20,12 @@ class UserModelAdmin(SqlAlchemyModelAdmin):
     list_filter = ("id", "username", "is_superuser")
     search_fields = ("username",)
     formfield_overrides = {  # noqa: RUF012
-        "username": (WidgetType.SlugInput, {"required": True}),
+        "username": (WidgetType.SlugInput, {"required": True,
+                                            # Changing the field label to a custom option
+                                            # "label": "Custom label",
+                                            # Adding a small text below the field to better understand the purpose of the field
+                                            # "help": "Detailed description of the field"
+                                            }),
         "password": (WidgetType.PasswordInput, {"passwordModalForm": True}),
         "avatar_url": (
             WidgetType.Upload,
@@ -129,7 +134,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(lifespan=lifespan)
-
 
 app.mount("/admin", admin_app)
 

--- a/frontend/src/components/form-container/index.tsx
+++ b/frontend/src/components/form-container/index.tsx
@@ -1,4 +1,4 @@
-import { Col, Collapse, Divider, Form, Row } from "antd";
+import {Col, Collapse, Divider, Form, Row, Typography} from "antd";
 import type React from "react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -101,7 +101,10 @@ export const FormContainer: React.FC<IFormContainer> = ({
         <Form.Item
           key={field.name}
           name={field.name}
-          label={getTitleFromFieldName(field.name)}
+          label={
+            getConf(field).form_widget_props?.label 
+            ? getConf(field)?.form_widget_props?.label 
+            : getTitleFromFieldName(field.name)}
           rules={
             [
               ...(getConf(field).required
@@ -166,6 +169,11 @@ export const FormContainer: React.FC<IFormContainer> = ({
           }
         >
           {getWidget(getConf(field))}
+          {getConf(field).form_widget_props?.help && 
+            <Typography.Text type={"secondary"} style={{marginTop: ".35rem", display: "flex"}}>
+              {getConf(field).form_widget_props?.help}
+            </Typography.Text>
+          }
         </Form.Item>
       ));
     },


### PR DESCRIPTION
### References

[Issues | [FAST API] Change label text # 87](https://github.com/vsdudakov/fastadmin/issues/87)

### Summary

Adds the ability to change a field's label to something more concise, correct, or simply in a different language. 
Adds help text below the field for a detailed description of the field's purpose.

it will look like this
<img width="563" height="171" alt="image" src="https://github.com/user-attachments/assets/29c632d8-34fa-4820-84e0-b77b9946ee33" />

### Are there any open tasks/blockers for the ticket?

The frontend has not been rebuilt