### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to FastAdmin are documented in this file.
 
-## Unreleased
+## 0.8.0
 
 - Add a `register_encoder(type_, encoder)` hook to control how a type is
   serialized in every admin API response (e.g. a custom datetime format, an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "fastadmin"
-version = "0.7.0"
+version = "0.8.0"
 description = "FastAdmin is an easy-to-use Admin Dashboard App for FastAPI/Flask/Django inspired by Django Admin."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "fastadmin"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION
Release **0.8.0**.

- Bump version `0.7.0` → `0.8.0` (`pyproject.toml`, `uv.lock`).
- Finalize CHANGELOG: promote the `Unreleased` entry to `## 0.8.0`.

### Included since 0.7.0
- `register_encoder(type_, encoder)` custom API value-serialization hook (#136, merged in #138).

Once merged, push tag `v0.8.0` to trigger the Release workflow (build + publish to PyPI).
